### PR TITLE
support for nutrimatic queries, improved ANSWERIZE and TO_MORSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.project

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Tools for easier group solving of Shinteki/Puzzle Hunt-type puzzles via Googledo
 
 | What the Function Does | Syntax |
 | -----------------------|--------|
-| Pull the [right/left] most N characters of a cell, including spaces | =right(CELL,N) / =left(CELL,N) |
-| Pull the middle N characters of a cell, starting with letter M | =mid(CELL, M, N) |
-| Find the first instance of string STR in cell | = FIND("STR",CELL) |
+| Pull the [right/left] most N characters of a cell, including spaces | =RIGHT(CELL,N) / =LEFT(CELL,N) |
+| Pull the middle N characters of a cell, starting with letter M | =MID(CELL, M, N) |
+| Find the first instance of string STR in cell | =FIND("STR",CELL) |
 | Remove spaces | =REGEXREPLACE(CELL," ","") |
-| Convert numeral to letter | =char(CELL+64) |
+| Convert numeral to letter | =CHAR(CELL+64) |
 
 # Features
 
@@ -30,7 +30,7 @@ sheet_functions/general.js | INDEX_IN_ALPHABET | INDEX_IN_ALPHABET(index)       
 sheet_functions/general.js | BINARY_TO_NUMBER  | BINARY_TO_NUMBER(string)          | Converts a binary string into a decimal number.
 sheet_functions/general.js | TERNARY_TO_NUMBER | TERNARY_TO_NUMBER(string)         | Converts a ternary string into a decimal number.
 sheet_functions/general.js | FROM_MORSE        | FROM_MORSE(string, [dot], [dash]) | Converts a string of Morse to plaintext. Supports optional dot and dash characters.
-sheet_functions/general.js | TO_MORSE          | TO_MORSE(string)                  | Converts a plaintext string to Morse
+sheet_functions/general.js | TO_MORSE          | TO_MORSE(string, [delimiter])     | Converts a plaintext string to Morse.  Separates characters in output with optional delimiter.
 sheet_functions/general.js | INDEX_IN_STRING   | INDEX_IN_STRING(string, index)    | Index into a string (shorthand for MID(string, index, 1))
 sheet_functions/general.js | SPLIT_INTO_CELLS  | SPLIT_INTO_CELLS(string)          | Put each character of the input into its own cell to the right.
 sheet_functions/general.js | ANSWERIZE         | ANSWERIZE(string, [spacesOnly])   | Strip non-alpha characters and uppercase the input.  Optionally strip spaces only.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ sheet_functions/general.js | BINARY_TO_NUMBER  | BINARY_TO_NUMBER(string)       
 sheet_functions/general.js | TERNARY_TO_NUMBER | TERNARY_TO_NUMBER(string)         | Converts a ternary string into a decimal number.
 sheet_functions/general.js | FROM_MORSE        | FROM_MORSE(string, [dot], [dash]) | Converts a string of Morse to plaintext. Supports optional dot and dash characters.
 sheet_functions/general.js | TO_MORSE          | TO_MORSE(string)                  | Converts a plaintext string of space-delimited characters to Morse
-sheet_functions/general.js | ANAGRAM           | ANAGRAM(string, [results])        | Look up anagrams and return n results (default is 10)
 sheet_functions/general.js | INDEX_IN_STRING   | INDEX_IN_STRING(string, index)    | Index into a string (shorthand for MID(string, index, 1))
 sheet_functions/general.js | SPLIT_INTO_CELLS  | SPLIT_INTO_CELLS(string)          | Put each character of the input into its own cell to the right.
-sheet_functions/general.js | ANSWERIZE         | ANSWERIZE(string)                 | Strip spaces and uppercase the input
+sheet_functions/general.js | ANSWERIZE         | ANSWERIZE(string, [spacesOnly])   | Strip non-alpha characters and uppercase the input.  Optionally strip spaces only.
+sheet_functions/general.js | ANAGRAM           | ANAGRAM(string, [results])        | Look up anagrams and return n results (default is 10)
+sheet_functions/general.js | NUTRIMATIC        | NUTRIMATIC(string, [results])     | Look up nutrimatic results for a query and return n results (default is 10)
+
 
 # Using custom functions in Google Sheets
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ sheet_functions/general.js | ANSWERIZE         | ANSWERIZE(string, [spacesOnly])
 sheet_functions/general.js | ANAGRAM           | ANAGRAM(string, [results])        | Look up anagrams and return n results (default is 10)
 sheet_functions/general.js | NUTRIMATIC        | NUTRIMATIC(string, [results])     | Look up nutrimatic results for a query and return n results (default is 10)
 
-
 # Using custom functions in Google Sheets
 
 1.  Tools -> Script Editor

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sheet_functions/general.js | INDEX_IN_ALPHABET | INDEX_IN_ALPHABET(index)       
 sheet_functions/general.js | BINARY_TO_NUMBER  | BINARY_TO_NUMBER(string)          | Converts a binary string into a decimal number.
 sheet_functions/general.js | TERNARY_TO_NUMBER | TERNARY_TO_NUMBER(string)         | Converts a ternary string into a decimal number.
 sheet_functions/general.js | FROM_MORSE        | FROM_MORSE(string, [dot], [dash]) | Converts a string of Morse to plaintext. Supports optional dot and dash characters.
-sheet_functions/general.js | TO_MORSE          | TO_MORSE(string)                  | Converts a plaintext string of space-delimited characters to Morse
+sheet_functions/general.js | TO_MORSE          | TO_MORSE(string)                  | Converts a plaintext string to Morse
 sheet_functions/general.js | INDEX_IN_STRING   | INDEX_IN_STRING(string, index)    | Index into a string (shorthand for MID(string, index, 1))
 sheet_functions/general.js | SPLIT_INTO_CELLS  | SPLIT_INTO_CELLS(string)          | Put each character of the input into its own cell to the right.
 sheet_functions/general.js | ANSWERIZE         | ANSWERIZE(string, [spacesOnly])   | Strip non-alpha characters and uppercase the input.  Optionally strip spaces only.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Tools for easier group solving of Shinteki/Puzzle Hunt-type puzzles via Googledo
 *  *Symmetrify Grid* - Make the selected cells have symmetry with regard to background color.
     Rotational (standard crossword) and bilateral are both supported.
 *  *Wordsmith Anagram Solver* - Open a sidebar that will allow querying wordsmith.org/anagram
+*  *Nutrimatic Solver* - Open a sidebar that will allow querying nutrimatic.org
 
 ## Added functions
 

--- a/html/web_query_form.html
+++ b/html/web_query_form.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 
 <div>
-<form name="solver" onSubmit="populateSolutions();return false;">
+<form name="solver" onSubmit="populateSolutions('<?= source ?>');return false;">
     <input type="text" name="searchText" id="searchText" /><br />
-    Number of Solutions: <input type="text" id="numSolutions" value="10" /><br />
+    Number of Solutions: <input type="text" id="numSolutions" value="30" /><br />
     <input type="submit" value="Find Results" />
 </form>
 <br />
@@ -12,3 +12,4 @@
 </div>
 
 <?!= include('web_query_js'); ?>
+

--- a/html/web_query_js.html
+++ b/html/web_query_js.html
@@ -32,11 +32,10 @@ function createTextNode(text) {
   return document.createTextNode(text);
 }
 
-function populateSolutions() {
+function populateSolutions(source) {
   var searchText = document.getElementById("searchText").value;
-  var maxResults = 10;
+  var maxResults = 30;
   var maxResultsString = document.getElementById("numSolutions").value;
-
   if (maxResultsString != "") {
     maxResults = parseInt(maxResultsString);
   }
@@ -58,6 +57,7 @@ function populateSolutions() {
       } else {
         setResultsText("No results");
       }
-   }).fetchAnagramsFromWordsmith(searchText, maxResults);
+   }).fetchResultsForSidePane(source, searchText, maxResults);
 }
 </script>
+

--- a/sheet_functions/caesar.js
+++ b/sheet_functions/caesar.js
@@ -9,8 +9,8 @@ var ASCII_LOW_MAX = 122;
 /**
  * A function that does a Caesar shift on a string, advancing each character a given amount through the alphabet.
  *
- * @param {String} the string to shift
- * @param {Number} the amount to shift by
+ * @param {string} initialString the string to shift
+ * @param {number} shiftAmount the amount to shift by
  * @return the shifted string
  * @customfunction
  */
@@ -18,7 +18,6 @@ function CAESAR_SHIFT(initialString, shiftAmount) {
   if (initialString == null) {
     return null;
   }
-
   return _forEachCharacterInEachWord(initialString, function(currentValue) {
     var asciiValue = currentValue.charCodeAt(0);
     if (_isInRange(asciiValue, ASCII_CAP_MIN, ASCII_CAP_MAX)) {

--- a/sheet_functions/general.js
+++ b/sheet_functions/general.js
@@ -230,7 +230,6 @@ function FROM_MORSE(input, dotChar, dashChar) {
     if (dashChar != undefined || dashChar != null) {
       normalizedString = _gsub(normalizedString, dashChar, '-');
     }
-
     return normalizedString in MORSE_TO_PLAIN ? MORSE_TO_PLAIN[normalizedString] : UNKNOWN_INPUT;
   }
   );
@@ -239,14 +238,17 @@ function FROM_MORSE(input, dotChar, dashChar) {
 /**
  * Given an input string, return the Morse code equivalent.
  * @param {string} input input string to convert
+ * @param {string=} delimiter the string used as a delimiter in the concatenated result string (optional, default=" ")
  * @return {string} the input encoded to Morse
  *
  * @customfunction
  */
-function TO_MORSE(input) {
-  return _forEachWord(input, function(word) {
-    return word in PLAIN_TO_MORSE ? PLAIN_TO_MORSE[word] : UNKNOWN_INPUT;
-  });
+function TO_MORSE(input, delimiter) {
+  if (_isNullOrUndefined(input)) { return null; }
+  if (_isNullOrUndefined(delimiter)) { delimiter = " "; }
+  return _forEachCharacterInEachWord(input.toUpperCase(), function(character) {
+    return character in PLAIN_TO_MORSE ? PLAIN_TO_MORSE[character] : UNKNOWN_INPUT;
+  }, delimiter);
 }
 
 /**
@@ -268,7 +270,6 @@ function _stringToDecimalString(input, radix, validatingRegex) {
  */
 function _forEachWord(input, callback) {
   if (_isNullOrUndefined(input)) {return null;}
-
   var words = input.toString().split(" ");
   return words.map( function(word) { return callback(word); } ).join(" ");
 }
@@ -277,24 +278,26 @@ function _forEachWord(input, callback) {
  * Calls the passed function once for each letter in the input string.
  * @param {string} input the input to process
  * @param {function} callback a callback function that will be executed for each character in the input. The callback function gets a single letter as an argument and should return a transformed value.
+ * @param {string=} delimiter the string used as a delimiter in the concatenated result string (optional, default="")
  * @return {string} the transformed characters concatenated back into a string.
  */
-function _forEachCharacter(input, callback) {
-  if (_isNullOrUndefined(input)) { return null;}
-
+function _forEachCharacter(input, callback, delimiter) {
+  if (_isNullOrUndefined(input)) { return null; }
+  if (_isNullOrUndefined(delimiter)) { delimiter = ""; }
   var chars = input.split("");
-  return chars.map(function(character) {return callback(character);}).join("");
+  return chars.map(function(character) {return callback(character);}).join(delimiter);
 }
 
 /**
  * Calls the passed function once for each character in each word. In other words, spaces between words will not be passed to the function.
  * @param {string} input the input string to process
  * @param {function} callback the callback function to use for each character in each word.
+ * @param {string=} delimiter the string used as a delimiter in the concatenated result string (optional, default="")
  * @return {string} the transformed string.
  */
-function _forEachCharacterInEachWord(input, callback) {
+function _forEachCharacterInEachWord(input, callback, delimiter) {
   return _forEachWord(input, function(word) {
-    return _forEachCharacter(word, function(character) { return callback(character);} );
+    return _forEachCharacter(word, function(character) { return callback(character);}, delimiter);
   });
 }
 

--- a/sheet_functions/general.js
+++ b/sheet_functions/general.js
@@ -4,7 +4,7 @@ ASCII_MIN = 65;
 ALPHABET_COUNT = 26;
 BINARY_STRING_REGEX = /^[0|1]+$/;
 TERNARY_STRING_REGEX = /^[0|1|2]+$/;
-UNKNOWN_INPUT = "??";
+UNKNOWN_INPUT = "?";
 
 NUTRIMATIC_SEARCH = "nutrimatic";
 WORDSMITH_SEARCH = "wordsmith";
@@ -85,7 +85,7 @@ function NUTRIMATIC(input, maxResults) {
 
 
 /**
- * Gets anagrams from wordsmith.org/anagram.
+ * Gets results from nutrimatic.org.
  */
 function fetchResultsFromNutrimatic(queryText, maxResults) {
   if (maxResults == undefined) {
@@ -120,7 +120,6 @@ function SPLIT_INTO_CELLS(input, delimiter) {
   if (input == null) {
     return null;
   }
-
   var chars = input.toString().split(delimiter == undefined || delimiter == null ? "" : delimiter);
   return [chars];
 }
@@ -157,8 +156,9 @@ function INDEX_IN_ALPHABET(index) {
  * @customfunction
  */
 function INDEX_IN_STRING(string, index) {
-  if (string == null) {return null;}
-
+  if (string == null) {
+    return null;
+  }
   // note that substring is 0 based, while the user will be using human numbers
   return _forEachWord(index, function(word) {
       var curIndex = parseInt(word);
@@ -221,11 +221,11 @@ function FROM_MORSE(input, dotChar, dashChar) {
     var normalizedString = new String(word);
 
     // convert word to dots and dashes
-    if (dotChar != undefined || dotChar != null) {
+    if (!_isNullOrUndefined(dotChar)) {
       normalizedString = _gsub(normalizedString, dotChar, '.');
     }
 
-    if (dashChar != undefined || dashChar != null) {
+    if (!_isNullOrUndefined(dashChar)) {
       normalizedString = _gsub(normalizedString, dashChar, '-');
     }
     return normalizedString in MORSE_TO_PLAIN ? MORSE_TO_PLAIN[normalizedString] : UNKNOWN_INPUT;

--- a/sheet_functions/general.js
+++ b/sheet_functions/general.js
@@ -38,7 +38,6 @@ function fetchResultsForSidePane(source, queryText, maxResults) {
 
 /**
  * Uses wordsmith.org Anagram Solver to return an array of anagrams.
- * Note that this relies on a
  * @param {string} input the text to anagram
  * @param {number=} maxResults the maximum number of results (optional, default=10)
  * @return {string[]} of results
@@ -74,7 +73,6 @@ function fetchResultsFromWordsmith(queryText, maxResults) {
 
 /**
  * Uses nutrimatic.org to return an array of results.
- * Note that this relies on a
  * @param {string} input the query text
  * @param {number=} maxResults the maximum number of results (optional, default=10)
  * @return {string[]} of results

--- a/sheet_functions/general.js
+++ b/sheet_functions/general.js
@@ -1,5 +1,3 @@
-// From: https://github.com/marie-cd/googledoc-puzzle-tools/blob/master/sheet_functions/general.js
-
 // a suite of generally useful functions.
 
 ASCII_MIN = 65;
@@ -41,9 +39,9 @@ function fetchResultsForSidePane(source, queryText, maxResults) {
 /**
  * Uses wordsmith.org Anagram Solver to return an array of anagrams.
  * Note that this relies on a
- * @param {String} the text to anagram
- * @param {Number} the maximum number of results.
- * @return {Array} of results
+ * @param {string} input the text to anagram
+ * @param {number=} maxResults the maximum number of results (optional, default=10)
+ * @return {string[]} of results
  *
  * @customfunction
  */
@@ -77,9 +75,9 @@ function fetchResultsFromWordsmith(queryText, maxResults) {
 /**
  * Uses nutrimatic.org to return an array of results.
  * Note that this relies on a
- * @param {String} the query text
- * @param {Number} the maximum number of results.
- * @return {Array} of results
+ * @param {string} input the query text
+ * @param {number=} maxResults the maximum number of results (optional, default=10)
+ * @return {string[]} of results
  *
  * @customfunction
  */
@@ -114,9 +112,10 @@ function fetchResultsFromNutrimatic(queryText, maxResults) {
 /**
  * Given an input string, split each character into its own cell.
  *
- * @param {String} text to split up
- * @param {String} character to split on (optional, defaults to empty space)
- * @return {Array} the individual characters of the input text.
+ * @param {string} input text to split up
+ * @param {string=} delimiter character to split on (default="")
+ * @return {string[]} the individual characters of the input text.
+ *
  * @customfunction
  */
 function SPLIT_INTO_CELLS(input, delimiter) {
@@ -132,8 +131,9 @@ function SPLIT_INTO_CELLS(input, delimiter) {
  * Gives the alphabetic character conforming to the given alphabet index.
  * For instance, INDEX_IN_ALPHABET(9) will return I.
  *
- * @param {Number} the number to use as an index into the alphabet
- * @return {String} the letter of the alphabet represented by that index. Blank if an invalid number.
+ * @param {number} index the number to use as an index into the alphabet
+ * @return {string} the letter of the alphabet represented by that index. Blank if an invalid number.
+ *
  * @customfunction
  */
 function INDEX_IN_ALPHABET(index) {
@@ -153,8 +153,9 @@ function INDEX_IN_ALPHABET(index) {
  * mechanism, so that INDEX_IN_STRING(string, "11 5") will return
  * the 11th letter and the fifth one.
  *
- * @param {String} the string to index into
- * @param {String} the 1-indexed index or indices to use for parsing the string.
+ * @param {string} string the string to index into
+ * @param {string} index the 1-indexed index or indices to use for parsing the string.
+ *
  * @customfunction
  */
 function INDEX_IN_STRING(string, index) {
@@ -167,30 +168,19 @@ function INDEX_IN_STRING(string, index) {
 }
 
 /**
- * Uppercases a string and removes the spaces.
+ * Uppercases a string and removes anything non-alphanumeric (except underscores).
  *
- * @param {String} string to answerize
- * @return {String} input string in all caps with the whitespace removed
+ * @param {string} input string to answerize
+ * @param {boolean=} spacesOnly only remove whitespace, keeping all other visible characters (optional, default=FALSE)
+ * @return {string} input answerized string in all caps
  * @customfunction
  */
-function ANSWERIZE_SPACES_ONLY(input) {
+function ANSWERIZE(input, spacesOnly) {
   if (input == null) {
     return null;
   }
-
-  return _gsub(input.toUpperCase()," ","");
-}
-
-/**
- * Uppercases a string and removes anything non-alphanumeric (except underscores).
- *
- * @param {String} string to answerize
- * @return {String} input string in all caps with the whitespace removed
- * @customfunction
- */
-function ANSWERIZE(input) {
-  if (input == null) {
-    return null;
+  if (spacesOnly) {
+    return input.toUpperCase().replace(/[\s]/g,"");
   }
   return input.toUpperCase().replace(/[^A-Z0-9_]/g,"");
 }
@@ -198,8 +188,8 @@ function ANSWERIZE(input) {
 /**
  * Converts a binary string into a decimal number.
  *
- * @param {String} binary sequence to convert
- * @return {Number} the decimal equivalent of the binary string
+ * @param {string} binaryString binary sequence to convert
+ * @return {number} the decimal equivalent of the binary string
  * @customfunction
  */
 function BINARY_TO_NUMBER(binaryString) {
@@ -209,8 +199,9 @@ function BINARY_TO_NUMBER(binaryString) {
 /**
  * Converts a ternary string into a decimal number.
  *
- * @param {String} ternary sequence to convert
- * @return {Number} the decimal equivalent of the ternary string.
+ * @param {string} ternaryString ternary sequence to convert
+ * @return {number} the decimal equivalent of the ternary string.
+ *
  * @customfunction
  */
 function TERNARY_TO_NUMBER(ternaryString) {
@@ -220,22 +211,24 @@ function TERNARY_TO_NUMBER(ternaryString) {
 /**
  * Given a string of morse code, convert it to plain text.
  *
- * @param {String} the input text convert
- * @param {String} the optional string to use for a dot
- * @param {String} the optional string to use for a dash
+ * @param {string} input the input text to convert
+ * @param {string=} dotChar the symbol to use for a dot (optional, default=".")
+ * @param {string=} dashChar the symbol to use for a dash (optional, default="-")
+ * @return {string} the decoded string
+ *
  * @customfunction
  */
-function FROM_MORSE(input, optDotChar, optDashChar) {
+function FROM_MORSE(input, dotChar, dashChar) {
   return _forEachWord(input, function(word) {
     var normalizedString = new String(word);
 
     // convert word to dots and dashes
-    if (optDotChar != undefined || optDotChar != null) {
-      normalizedString = _gsub(normalizedString, optDotChar, '.');
+    if (dotChar != undefined || dotChar != null) {
+      normalizedString = _gsub(normalizedString, dotChar, '.');
     }
 
-    if (optDashChar != undefined || optDashChar != null) {
-      normalizedString = _gsub(normalizedString, optDashChar, '-');
+    if (dashChar != undefined || dashChar != null) {
+      normalizedString = _gsub(normalizedString, dashChar, '-');
     }
 
     return normalizedString in MORSE_TO_PLAIN ? MORSE_TO_PLAIN[normalizedString] : UNKNOWN_INPUT;
@@ -245,8 +238,9 @@ function FROM_MORSE(input, optDotChar, optDashChar) {
 
 /**
  * Given an input string, return the Morse code equivalent.
- * @param {String} input string to convert
- * @return {String} the input encoded to Morse
+ * @param {string} input input string to convert
+ * @return {string} the input encoded to Morse
+ *
  * @customfunction
  */
 function TO_MORSE(input) {
@@ -268,9 +262,9 @@ function _stringToDecimalString(input, radix, validatingRegex) {
 /**
  * Calls the passed function once for each word (space-delimited) in the input.
  *
- * @param {String} the input to be parsed
- * @param {Function} a callback function to be executed for each word in the input. The callback function will take a single String as its input.
- * @return {String} the concatenated results of each call to callback for each word.
+ * @param {string} input the input to be parsed
+ * @param {function} callback a callback function to be executed for each word in the input. The callback function will take a single String as its input.
+ * @return {string} the concatenated results of each call to callback for each word.
  */
 function _forEachWord(input, callback) {
   if (_isNullOrUndefined(input)) {return null;}
@@ -281,9 +275,9 @@ function _forEachWord(input, callback) {
 
 /**
  * Calls the passed function once for each letter in the input string.
- * @param {String} the input to process
- * @param {Function} a callback function that will be executed for each character in the input. The callback function gets a single letter as an argument and should return a transformed value.
- * @return {String} the transformed characters concatenated back into a string.
+ * @param {string} input the input to process
+ * @param {function} callback a callback function that will be executed for each character in the input. The callback function gets a single letter as an argument and should return a transformed value.
+ * @return {string} the transformed characters concatenated back into a string.
  */
 function _forEachCharacter(input, callback) {
   if (_isNullOrUndefined(input)) { return null;}
@@ -294,9 +288,9 @@ function _forEachCharacter(input, callback) {
 
 /**
  * Calls the passed function once for each character in each word. In other words, spaces between words will not be passed to the function.
- * @param {String} the input string to process
- * @param {Function} the callback function to use for each character in each word.
- * @return {String} the transformed string.
+ * @param {string} input the input string to process
+ * @param {function} callback the callback function to use for each character in each word.
+ * @return {string} the transformed string.
  */
 function _forEachCharacterInEachWord(input, callback) {
   return _forEachWord(input, function(word) {
@@ -307,8 +301,8 @@ function _forEachCharacterInEachWord(input, callback) {
 
 /**
  * Checks whether the value is null or undefined
- * @param {Object} a value to check
- * @return {Boolean} true if the object is null or undefined, false if not.
+ * @param {Object} value a value to check
+ * @return {boolean} true if the object is null or undefined, false if not.
  */
 function _isNullOrUndefined(value) {
   return value == null || value == undefined;
@@ -318,9 +312,9 @@ function _isNullOrUndefined(value) {
 /**
  * Given a string, replace all instances of one string with another.
  *
- * @param {String} unmodified string
- * @param {String} string to replace
- * @param {String} string to use as substitute
+ * @param {string} inputString unmodified string
+ * @param {string} replaceString string to replace
+ * @param {string} substituteString string to use as substitute
  */
 function _gsub(inputString, replaceString, substituteString) {
   if (inputString == null || replaceString == null || substituteString == null) {

--- a/sheet_functions/general.js
+++ b/sheet_functions/general.js
@@ -117,7 +117,7 @@ function INDEX_IN_STRING(string, index) {
  * @return {String} input string in all caps with the whitespace removed
  * @customfunction
  */
-function ANSWERIZE(input) {
+function ANSWERIZE_SPACES_ONLY(input) {
   if (input == null) {
     return null;
   }
@@ -125,6 +125,19 @@ function ANSWERIZE(input) {
   return _gsub(input.toUpperCase()," ","");
 }
 
+/**
+ * Uppercases a string and removes anything non-alphanumeric (except underscores).
+ *
+ * @param {String} string to answerize
+ * @return {String} input string in all caps with the whitespace removed
+ * @customfunction
+ */
+function ANSWERIZE(input) {
+  if (input == null) {
+    return null;
+  }
+  return input.toUpperCase().replace(/[^A-Z0-9_]/g,"");
+}
 
 /**
  * Converts a binary string into a decimal number.

--- a/ui_functions/menu_items.js
+++ b/ui_functions/menu_items.js
@@ -10,6 +10,7 @@ function onOpen() {
       .addItem('Quick-Add Named Tabs', 'doAddNamedTabs')
       .addSeparator()
       .addItem('Wordsmith Anagram Solver', 'doOpenWordsmithAnagrammer')
+      .addItem('Nutrimatic Solver', 'doOpenNutrimatic')
       .addToUi();
 }
 
@@ -143,17 +144,24 @@ function doSetupSimpleSubstitutionKey() {
  * Creates the sidebar necessary for querying wordsmith.org/anagram
  */
 function doOpenWordsmithAnagrammer() {
-  var html = HtmlService.createTemplateFromFile('web_query_form')
-      .evaluate()
-      .setSandboxMode(HtmlService.SandboxMode.IFRAME)
-      .setTitle('Wordsmith Anagrammer');
+  var template = HtmlService.createTemplateFromFile('web_query_form')
+  template.source = WORDSMITH_SEARCH;
+  var html = template.evaluate().setTitle('Wordsmith Anagrammer');
+  _getSpreadsheetUI().showSidebar(html);
+}
+
+/**
+ * Creates the sidebar necessary for querying wordsmith.org/anagram
+ */
+function doOpenNutrimatic() {
+  var template = HtmlService.createTemplateFromFile('web_query_form')
+  template.source = NUTRIMATIC_SEARCH;
+  var html = template.evaluate().setTitle('Nutrimatic');
   _getSpreadsheetUI().showSidebar(html);
 }
 
 function include(filename) {
-  return HtmlService.createHtmlOutputFromFile(filename)
-      .setSandboxMode(HtmlService.SandboxMode.IFRAME)
-      .getContent();
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
 }
 
 /**


### PR DESCRIPTION
Improvements include:
- added a second side panels for Nutrimatic queries similar to the existing Wordsmith one (and refactored code to reuse the same template)
- improved ANSWERIZE function to strip all non-alphanumeric characters, but added an optional boolean argument to get the old behavior
- added NUTRIMATIC function that works similarly to the existing ANAGRAM function, but for Nutrimatic queries
- fixes TO_MORSE to work on more than one character at a time
- updated JSDoc on all the functions to make their usage more clearly documented in autocomplete